### PR TITLE
⏫ bump github-action-add-on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
         description: 'Debug with tmate set "debug_enabled"'
         required: false
         default: "false"
-        
+
 jobs:
   tests:
     strategy:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v0
+    - uses: ddev/github-action-add-on-test@v1
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,69 +13,21 @@ on:
         description: 'Debug with tmate set "debug_enabled"'
         required: false
         default: "false"
-
-defaults:
-  run:
-    shell: bash
-
-env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
-  # Allow ddev get to use a github token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+        
 jobs:
   tests:
-    defaults:
-      run:
-        shell: bash
-
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-#        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-    - name: Environment setup
-      run: |
-        brew install bats-core mkcert
-        mkcert -install
-
-    - name: Use ddev stable
-      if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
-
-    - name: Use ddev edge
-      if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
-
-    - name: Use ddev HEAD
-      if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
-
-    - name: Use ddev PR
-      if: matrix.ddev_version == 'PR'
-      run: |
-        curl -sSL -o ddev_linux.zip ${NIGHTLY_DDEV_PR_URL}
-        unzip ddev_linux.zip
-        mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
-
-    - name: Download docker images
-      run: | 
-        mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-        docker pull memcached:1.6 >/dev/null
-    - name: tmate debugging session
-      uses: mxschmitt/action-tmate@v3
+    - uses: ddev/github-action-add-on-test@v0
       with:
-        limit-access-to-actor: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
-    - name: tests
-      run: bats tests
+        ddev_version: ${{ matrix.ddev_version }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        debug_enabled: ${{ github.event.inputs.debug_enabled }}
+        addon_repository: ${{ env.GITHUB_REPOSITORY }}
+        addon_ref: ${{ env.GITHUB_REF }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: "false"
 
+# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+permissions:
+  actions: write
+
 jobs:
   tests:
     strategy:
@@ -24,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
 
   schedule:
   - cron: '25 08 * * *'

--- a/backstopBuild/Dockerfile
+++ b/backstopBuild/Dockerfile
@@ -16,7 +16,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 # Add sudo and sudoers in manner similar to other ddev containers
 RUN apt update && apt install -y sudo; apt clean -qq && rm -rf /var/lib/apt/lists/*; echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/ddev-backstop && chmod 440 /etc/sudoers.d/ddev-backstop
 
-RUN npm install -g minimist && npm cache clean --force
+RUN npm install -g minimist
 
 # Install playwright browsers
 RUN npx playwright install-deps && npm cache clean --force; apt clean -qq && rm -rf /var/lib/apt/lists/*

--- a/commands/backstop/backstop
+++ b/commands/backstop/backstop
@@ -8,7 +8,7 @@
 ## ExecRaw: true
 
 if [ "$1" == "openReport" -o "$1" == "remote" ]; then
-  echo "This does not work for backstop in ddev"
+  echo "This does not work for backstop in ddev. See ddev backstop-results command."
   exit 1
 fi
 

--- a/commands/host/backstop-results
+++ b/commands/host/backstop-results
@@ -8,12 +8,12 @@
 
 case $OSTYPE in
   linux-gnu)
-    xdg-open tests/backstop/backstop_data/html_report/index.html
+    xdg-open ${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html
     ;;
   "darwin"*)
-    open tests/backstop/backstop_data/html_report/index.html
+    open ${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html
     ;;
   "win*"* | "msys"*)
-    start tests/backstop/backstop_data/html_report/index.html
+    start ${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html
     ;;
 esac

--- a/docker-compose.backstop.yaml
+++ b/docker-compose.backstop.yaml
@@ -11,11 +11,11 @@ services:
     build:
       context: './backstopBuild'
       args:
-        BASE_IMAGE: backstopjs/backstopjs:6.2.2
+        BASE_IMAGE: backstopjs/backstopjs:6.3.3
         username: $USER
         uid: $DDEV_UID
         gid: $DDEV_GID
-    image: backstopjs/backstopjs:6.2.2-${DDEV_SITENAME}-built
+    image: backstopjs/backstopjs:6.3.3-${DDEV_SITENAME}-built
     user:  '$DDEV_UID:$DDEV_GID'
     # Add init to reap Chrome processes, as noted at
     # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker

--- a/install.yaml
+++ b/install.yaml
@@ -3,7 +3,7 @@ name: ddev-backstopjs
 pre_install_actions:
   - test -d ${DDEV_APPROOT}/tests/backstop || mkdir -p ${DDEV_APPROOT}/tests/backstop
   - test -f "${DDEV_APPROOT}/tests/backstop/.gitignore" || printf "## ddev-generated\n**/bitmaps_test\n**/html_report\n" > ${DDEV_APPROOT}/tests/backstop/.gitignore
-  - grep -q "## ddev-generated" ${DDEV_APPROOT}/tests/backstop/.gitignore && printf "## ddev-generated\n**/bitmaps_test\n**/html_report\n" > ${DDEV_APPROOT}/tests/backstop/.gitignore
+  - grep -q "## ddev-generated" ${DDEV_APPROOT}/tests/backstop/.gitignore && printf "## ddev-generated\n**/bitmaps_test\n**/html_report\n" > ${DDEV_APPROOT}/tests/backstop/.gitignore || true
 
 
 # list of files and directories listed that are copied into project .ddev directory


### PR DESCRIPTION
This PR bumps github-action-add-on to v2.
This prevents the dummy commits created by the keep-alive action.

@see https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0